### PR TITLE
enable search for expropt by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ program into circuit backend description.
 
 ## Build instructions:
 
-* in `config.in`, specify which logic opimizer is available. If no optimizer is
-  available, leave it blank. If an open-source optimizer is available, specify
-  it as `expropt`. If a commercial optimizer is available, then add
-  `exproptcommercial` in a new line after `expropt`
 * to compile the tool, run `sh build.sh`, and the binary is located at
   `bin/dflowmap`
 * to install the tool, go into the `build` directory and type `make install`

--- a/config.in
+++ b/config.in
@@ -1,0 +1,3 @@
+expropt
+exproptcommercial
+dflow_backend_netlist


### PR DESCRIPTION
for actflow enable search for expropt and other add-ons by default,

because the configure script is checking if the add-ons exist anyway, there is no need to require manual interaction of listing add-ons as mentioned in the read me